### PR TITLE
build.sh: Add clean_all command and align with QSDK standards

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,60 @@
 #!/bin/sh
 
-echo "Delete old u-boot files"
-if [ -f "u-boot.bin" ]; then
-    rm u-boot.bin
-fi
-if [ -f "u-boot-2016/u-boot" ]; then
-    rm u-boot-2016/u-boot
+if [ "$1" = "clean_all" ]; then
+	echo "Delete old u-boot files"
+	# Only delete the specified core files
+	if [ -f "openwrt-ipq6018-u-boot.mbn" ]; then
+		rm openwrt-ipq6018-u-boot.mbn
+	fi
+	exit 0
+elif [ "$1" = "clean" ]; then
+	echo "Delete old u-boot files"
+	# Keep existing clean logic with all deletion rules
+	if [ -f "openwrt-ipq6018-u-boot.mbn" ]; then
+		rm openwrt-ipq6018-u-boot.mbn
+	fi
+	echo "Deep clean by .gitignore rules"
+	find u-boot-2016 -type f \
+		\( \
+			-name '*.o' -o \
+			-name '*.o.*' -o \
+			-name '*.a' -o \
+			-name '*.s' -o \
+			-name '*.su' -o \
+			-name '*.mod.c' -o \
+			-name '*.i' -o \
+			-name '*.lst' -o \
+			-name '*.order' -o \
+			-name '*.elf' -o \
+			-name '*.swp' -o \
+			-name '*.bin' -o \
+			-name '*.patch' -o \
+			-name '*.cfgtmp' -o \
+			-name '*.exe' -o \
+			-name 'MLO*' -o \
+			-name 'SPL' -o \
+			-name 'System.map' -o \
+			-name 'LOG' -o \
+			-name '*.orig' -o \
+			-name '*~' -o \
+			-name '#*#' -o \
+			-name 'cscope.*' -o \
+			-name 'tags' -o \
+			-name 'ctags' -o \
+			-name 'etags' -o \
+			-name 'GPATH' -o \
+			-name 'GRTAGS' -o \
+			-name 'GSYMS' -o \
+			-name 'GTAGS' \
+		\) -delete
+	rm -rf \
+		.stgit-edit.txt \
+		.gdb_history \
+		u-boot-2016/arch/arm/dts/dtbtable.S \
+		u-boot-2016/httpd/fsdata.c \
+		u-boot-2016/scripts_mbn/mbn_tools.pyc \
+		u-boot-2016/u-boot*
+	exit 0
 fi
 
 echo "Set Compilation Environment"
@@ -24,6 +73,6 @@ echo "Convert elf to mbn"
 python2.7 scripts_mbn/elftombn.py -f ./u-boot -o ./u-boot.mbn -v 6
 
 echo "Copy u-boot.mbn to root directory"
-mv ./u-boot.mbn ../u-boot.bin
+mv ./u-boot.mbn ../openwrt-ipq6018-u-boot.mbn
 
 echo "Done!"


### PR DESCRIPTION
- Add 'clean_all' parameter to delete core files only
- Optimize 'clean' parameter with proper line breaks for readability
- Correct final file name to match QSDK specifications